### PR TITLE
Update add-peer

### DIFF
--- a/root/app/add-peer
+++ b/root/app/add-peer
@@ -33,6 +33,7 @@ DUDE"
 [Peer]
 PublicKey = $(cat /config/peer${i}/publickey-peer${i})
 AllowedIPs = ${INTERFACE}.$(( $i + 1 ))/32
+PersistentKeepalive = 60
 
 DUDE
     echo "PEER ${i} QR code:"


### PR DESCRIPTION
Ensures Peers can see each other

<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]
	
New clients where not able to ping each other if the subnet is not used as default route.
